### PR TITLE
Update face_detect.py

### DIFF
--- a/face_detect.py
+++ b/face_detect.py
@@ -18,7 +18,7 @@ faces = faceCascade.detectMultiScale(
     scaleFactor=1.1,
     minNeighbors=5,
     minSize=(30, 30),
-    flags = cv2.cv.CV_HAAR_SCALE_IMAGE
+    flags = cv2.CASCADE_SCALE_IMAGE
 )
 
 print("Found {0} faces!".format(len(faces)))


### PR DESCRIPTION
The latest openCV no longer allows importing the legacy cv module.
In openCV 3, I believe this constant is now referenced as follows: cv2.CASCADE_SCALE_IMAGE